### PR TITLE
ci: run test build without publishing in PRs

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,6 +3,8 @@ name: Create and publish Docker image
 on:
   push:
     branches: ['main']
+  pull_request:
+    branches: [ main ]
 
 env:
   REGISTRY: ghcr.io
@@ -32,6 +34,6 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
-          push: true
+          push: ${{ github.ref == 'refs/heads/main' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,12 @@
 FROM ubuntu:latest
 
 RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get -y install git cmake wget software-properties-common build-essential pkg-config python3-minimal libssl-dev libsqlite3-dev libopencv-dev clang-format && \
+    DEBIAN_FRONTEND=noninteractive apt-get -y install git cmake wget software-properties-common build-essential pkg-config python3-minimal libssl-dev libsqlite3-dev libopencv-dev clang-format libboost-all-dev && \
     ln -s /usr/include/opencv4 /usr/local/include/opencv4 && \
     # Install nlohmann-json
-    add-apt-repository ppa:team-xbmc/ppa && \
+    add-apt-repository ppa:team-xbmc/ppa &&  \
     apt-get update && \
     apt-get -y install nlohmann-json3-dev && \
-    # Install libboost
-    wget https://sourceforge.net/projects/boost/files/boost/1.76.0/boost_1_76_0.tar.bz2 && \
-    tar xfo boost_1_76_0.tar.bz2 && \
-    cd boost_1_76_0 && \
-    ./bootstrap.sh && \
-    ./b2 --with=all install && \
-    cd .. && \
-    rm -rf boost_1_76_0 && \
     # Install ndn-cxx
     git clone https://github.com/named-data/ndn-cxx && \
     cd ndn-cxx && \


### PR DESCRIPTION
This PR allows the CI to run a "test build" of the image in PRs to identify potential issues before pushing to the main branch.